### PR TITLE
Use g6R::toolbar() in examples and docs (bslib collision)

### DIFF
--- a/R/plugins.R
+++ b/R/plugins.R
@@ -94,7 +94,7 @@
 #'         // do stuff
 #'     }")
 #'   ),
-#'   toolbar(
+#'   g6R::toolbar(
 #'     position = "top-right",
 #'     getItems = JS("() => [
 #'       { id: 'zoom-in', value: 'zoom-in' },
@@ -2019,7 +2019,7 @@ timebar <- function(
 #'
 #' @examples
 #' # Basic toolbar with zoom controls
-#' config <- toolbar(
+#' config <- g6R::toolbar(
 #'   position = "top-right",
 #'   getItems = JS("() => [
 #'     { id: 'zoom-in', value: 'zoom-in' },

--- a/inst/examples/demo/app.R
+++ b/inst/examples/demo/app.R
@@ -171,7 +171,7 @@ server <- function(input, output, session) {
         "brush-select"
       ) |>
       g6_plugins(
-        toolbar(
+        g6R::toolbar(
           style = list(
             backgroundColor = "#f5f5f5",
             padding = "8px",

--- a/inst/examples/dynamic/app.R
+++ b/inst/examples/dynamic/app.R
@@ -140,7 +140,7 @@ server <- function(input, output, session) {
           ),
           trigger = "click"
         ),
-        toolbar(
+        g6R::toolbar(
           style = list(
             backgroundColor = "#f5f5f5",
             padding = "8px",

--- a/man/g6_plugins.Rd
+++ b/man/g6_plugins.Rd
@@ -104,7 +104,7 @@ plugins <- g6_plugins(
         // do stuff
     }")
   ),
-  toolbar(
+  g6R::toolbar(
     position = "top-right",
     getItems = JS("() => [
       { id: 'zoom-in', value: 'zoom-in' },

--- a/man/toolbar.Rd
+++ b/man/toolbar.Rd
@@ -40,7 +40,7 @@ This plugin adds a customizable toolbar with items for graph operations.
 }
 \examples{
 # Basic toolbar with zoom controls
-config <- toolbar(
+config <- g6R::toolbar(
   position = "top-right",
   getItems = JS("() => [
     { id: 'zoom-in', value: 'zoom-in' },

--- a/vignettes/articles/plugins.Rmd
+++ b/vignettes/articles/plugins.Rmd
@@ -196,7 +196,7 @@ g6(nodes, edges) |>
     nodes = nodes_options
   ) |>
   g6_plugins(
-    toolbar(),
+    g6R::toolbar(),
     fullscreen()
   )
 ```
@@ -342,7 +342,7 @@ g6(nodes, edges) |>
     node = nodes_options
   ) |>
   g6_plugins(
-    toolbar(
+    g6R::toolbar(
       getItems = JS(
         "() => [
           { id: 'undo', value: 'undo' },


### PR DESCRIPTION
## Problem

`{bslib}` ships its own `toolbar()` that collides with g6R's. When bslib is attached after g6R (e.g. `devtools::load_all()` during dev, or any app's `library()` order), `bslib::toolbar` masks `g6R::toolbar`. A bare `toolbar()` then returns a bslib tag list with no `type`, and `g6_plugins()` rejects it:

```
'unknown' is not a valid plugin. Valid choices are: background, bubble-sets, contextmenu, ...
```

This is the collision already documented in the NEWS breaking-change note.

## Fix

Qualify the call as `g6R::toolbar()` in all user-facing, copy-pasteable spots:

- `inst/examples/demo/app.R` and `inst/examples/dynamic/app.R` (both `library(bslib)`)
- `vignettes/articles/plugins.Rmd` (2 usages)
- `g6_plugins()` and `toolbar()` roxygen `@examples` (Rd regenerated)

Left unchanged:
- Tests (`test-plugins.R`): run in the g6R namespace, no bslib attached.
- The `toolbar()` function definition.
- `nodes.Rmd` prose mention (inline text, not executable).
- README: does not call `toolbar()`.

## Verification

Reproduced the error under `load_all()` (bslib masks g6R), confirmed `g6R::toolbar()` resolves correctly (`type = "toolbar"`), and the demo app renders with no plugin-validation error after the fix.